### PR TITLE
Expansion of passing analysis

### DIFF
--- a/nba_analysis/analysis/passing.py
+++ b/nba_analysis/analysis/passing.py
@@ -2,7 +2,7 @@ import pandas as pd
 import networkx as nx
 import matplotlib.pyplot as plt
 from networkx.readwrite import json_graph
-from sklearn.cluster import AffinityPropagation, AgglomerativeClustering
+from sklearn.cluster import AffinityPropagation, SpectralClustering
 
 import sys
 
@@ -57,8 +57,7 @@ def get_passing_clusters(df, team):
     mat = nx.adjacency_matrix(g, nodelist=None, weight='label')
     mat = 1 - mat.todense()
 
-    clstr = AgglomerativeClustering(n_clusters=3, affinity='precomputed',
-                                    linkage='complete')
+    clstr = SpectralClustering(n_clusters=3, affinity='precomputed')
     res = clstr.fit(mat)
 
     return res.labels_

--- a/nba_analysis/analysis/passing.py
+++ b/nba_analysis/analysis/passing.py
@@ -2,6 +2,7 @@ import pandas as pd
 import networkx as nx
 import matplotlib.pyplot as plt
 from networkx.readwrite import json_graph
+from sklearn.cluster import AffinityPropagation, AgglomerativeClustering
 
 import sys
 
@@ -36,6 +37,31 @@ def get_passing_info(df, team):
     df = df[df['TEAM_NAME'] == team]
     g, shots = construct_graph(df)
     return json_graph.node_link_data(g), shots
+
+
+def get_usage_clusters(df, team):
+    df = df[df['TEAM_NAME'] == team]
+    g = construct_graph(df)[0]
+    mat = nx.adjacency_matrix(g, nodelist=None, weight='label')
+    mat = 1 - mat.todense()
+
+    clstr = AffinityPropagation()
+    res = clstr.fit(mat)
+
+    return res.labels_
+
+
+def get_passing_clusters(df, team):
+    df = df[df['TEAM_NAME'] == team]
+    g = construct_graph(df)[0]
+    mat = nx.adjacency_matrix(g, nodelist=None, weight='label')
+    mat = 1 - mat.todense()
+
+    clstr = AgglomerativeClustering(n_clusters=3, affinity='precomputed',
+                                    linkage='complete')
+    res = clstr.fit(mat)
+
+    return res.labels_
 
 
 if __name__ == '__main__':

--- a/nba_analysis/webapp/__init__.py
+++ b/nba_analysis/webapp/__init__.py
@@ -1,7 +1,9 @@
 from nba_analysis.analysis.positions import classify_player_position
 from nba_analysis.analysis.tiers import cluster as tier_cluster
 from nba_analysis.analysis.styles import cluster as style_cluster
-from nba_analysis.analysis.passing import get_passing_info
+from nba_analysis.analysis.passing import (get_passing_info,
+                                           get_usage_clusters,
+                                           get_passing_clusters)
 from nba_analysis import config
 
 from flask import Flask, render_template, request, json
@@ -70,6 +72,20 @@ def get_passing():
     graph_json, shots = get_passing_info(df, team)
     packaged_json = {'graph': graph_json, 'shot_probs': shots}
     return json.dumps(packaged_json)
+
+
+@app.route('/_get_pass_clusters')
+def get_pass_clusters():
+    clst_type = request.args.get('type')
+    team = request.args.get('team')
+    df = get_data_source('passing_data')
+
+    if clst_type == 'usage':
+        results = get_usage_clusters(df, team)
+    elif clst_type == 'passing':
+        results = get_passing_clusters(df, team)
+    results = {'clusters': results.tolist()}
+    return json.dumps(results)
 
 
 @app.route('/_get_positions')

--- a/nba_analysis/webapp/templates/passing.html
+++ b/nba_analysis/webapp/templates/passing.html
@@ -223,6 +223,8 @@
           var numPossesions = parseInt(possessionsInput.value);
 
           document.getElementById('simulateButton').disabled = true;
+          document.getElementById('usageClusters').disabled = true;
+          document.getElementById('passingClusters').disabled = true;
 
           for (count = 0; count < numPossesions; count++) {
             var path = findPath();
@@ -242,6 +244,8 @@
           }
           setTimeout(function () {
             document.getElementById('simulateButton').disabled = false;
+            document.getElementById('usageClusters').disabled = false;
+            document.getElementById('passingClusters').disabled = false;
           }, 5000);
         }
 
@@ -264,15 +268,14 @@
           var url = '/_get_pass_clusters?team=' + team + '&type=' + type;
           d3.json(url, function(cluster_data) {
             assignments = cluster_data['clusters'];
-            console.log(cluster_data);
             graph.nodes.forEach(function (n, i) {
               if (i < assignments.length) {
                 n.group = assignments[i] + 2;
-                console.log(n.group);
               }
               else {
                 n.group = 0;
               }
+              visibleLinks = [];
               restart();
             });
           });

--- a/nba_analysis/webapp/templates/passing.html
+++ b/nba_analysis/webapp/templates/passing.html
@@ -12,6 +12,8 @@
     var w = 800,
         h = 500;
 
+    var color = d3.scale.category20().domain(d3.range(0, 20));
+
     function drawGraph() {
       // Remove the previous svg
       d3.select('svg').remove();
@@ -114,8 +116,11 @@
               return d.y;
             })
             .style('fill', function (d) {
-              if (d.group === 0) {
-                return 'rgb(31, 119, 180)';
+              if (d.group === 1) {
+                return color(42);
+              }
+              else if (d.group < 42) {
+                return color(d.group);
               }
               else {
                 return 'rgb(255, 127, 14)'
@@ -183,7 +188,7 @@
 
           graph.nodes.forEach(function (n) {
             if (n.index === path[0]) {
-              n.group = 1;
+              n.group = 42;
             }
             else {
               n.group = 0;
@@ -200,7 +205,7 @@
               });
               graph.nodes.forEach(function (n) {
                 if (n.index === path[i+1]) {
-                  n.group = 1;
+                  n.group = 42;
                 }
               });
               restart();
@@ -258,7 +263,18 @@
         function clusters(type) {
           var url = '/_get_pass_clusters?team=' + team + '&type=' + type;
           d3.json(url, function(cluster_data) {
+            assignments = cluster_data['clusters'];
             console.log(cluster_data);
+            graph.nodes.forEach(function (n, i) {
+              if (i < assignments.length) {
+                n.group = assignments[i] + 2;
+                console.log(n.group);
+              }
+              else {
+                n.group = 0;
+              }
+              restart();
+            });
           });
         }
 

--- a/nba_analysis/webapp/templates/passing.html
+++ b/nba_analysis/webapp/templates/passing.html
@@ -17,6 +17,8 @@
       d3.select('svg').remove();
       d3.select('#numPossesions').remove();
       d3.select('#simulateButton').remove();
+      d3.select('#usageClusters').remove();
+      d3.select('#passingClusters').remove();
       var possessionsLog = document.getElementById('log');
       while (possessionsLog.rows.length > 1) {
         possessionsLog.deleteRow(1);
@@ -252,6 +254,31 @@
           .attr('id', 'simulateButton')
           .text('Simulate')
           .on('click', runSimulation);
+
+        function clusters(type) {
+          var url = '/_get_pass_clusters?team=' + team + '&type=' + type;
+          d3.json(url, function(cluster_data) {
+            console.log(cluster_data);
+          });
+        }
+
+        d3.select('#chartDetail')
+          .append('button')
+          .attr('type', 'button')
+          .attr('id', 'usageClusters')
+          .text('Usage Clusters')
+          .on('click', function(d){
+            clusters('usage')
+          });
+
+        d3.select('#chartDetail')
+          .append('button')
+          .attr('type', 'button')
+          .attr('id', 'passingClusters')
+          .text('Passing Clusters')
+          .on('click', function(d){
+            clusters('passing')
+          });
       });
     }
   </script>


### PR DESCRIPTION
Now can cluster players within the passing graph. Corresponding visualization added.

Usage clusters - groups players based on which other players they pass to, this usually groups the roster into positions (i.e. guards are similar to each other in that they pass to wings/bigs)

Passing clusters - groups players based on likelihood they pass to each other, this usually groups the roster into players with good chemistry/commonly play together